### PR TITLE
支持免安装 Python 使用 JM 功能，增加模块安装失败的处理逻辑

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,23 @@ socket5 或者 http 代理
 打开`config/config/jm.yaml`
 
 _按照注释填写内容无特殊需求不需要更改_
-然后`安装Python`
+
+> [!WARNING]
+> 由于 pnpm v10+ 修改了规则，需要运行以下命令完成模块安装以保证PDF加密功能正常
+
+```sh
+pnpm approve-builds muhammara
+```
+
+> 如果在 `pnpm i` 时运行过 `pnpm approve-builds` 并勾选上 `muhammara` 则可以忽略，具体查看是否有日志提示为准
+
+新版插件运行 `pnpm install` 会自动下载对应的 `jmcomic` 版本，如果没有自动安装对应版本或无法使用请根据下方指引手工安装 Python 使用
+
+<details><summary>旧版Python方案</summary>
+
+> 新版本此方案已被替代，仅当无法使用时的备用方案作用
+
+自行 `安装Python`
 执行
 
 ```bash
@@ -67,7 +83,7 @@ pipx runpip jmcomic install img2pdf
 
 ### Windows环境变量配置
 
-如果你使用Windows系统，需要额外配置以下环境变量:
+如果你使用Windows系统，可能需要额外配置以下环境变量:
 
 1. 打开系统环境变量设置
    - 右键"此电脑" -> 属性 -> 高级系统设置 -> 环境变量
@@ -87,6 +103,7 @@ pipx runpip jmcomic install img2pdf
 
 4. 重启终端和云崽后即可正常使用
 
+</details>
 
 
 ## PDF生成模式

--- a/model/JM/index.js
+++ b/model/JM/index.js
@@ -1,11 +1,11 @@
-import { spawn } from 'child_process'
+import { spawn, execFile } from 'child_process'
 import fs from 'fs/promises'
 import path from 'path'
+import { promisify } from 'util'
 import Path from '../../components/Path.js'
 import YamlReader from '../../components/YamlReader.js'
 import Config from '../../components/Config.js'
 import Logger from '../utils/Logger.js'
-import muhammara from 'muhammara'
 import jmcomic from '@jmcomic/jmcomic'
 import Yaml from 'yaml'
 const cfg = Config.getConfig('jm')
@@ -35,6 +35,12 @@ const Configs = {
     },
 }
 let Cfg_yaml
+/**
+ * 初始化 JM 资源目录和配置文件。
+ * - 确保图片和 PDF 的目录存在
+ * - 如果缺少 option.yml 则写入默认配置
+ * - 初始化 YamlReader 配置读取器
+ */
 async function init() {
     await fs.mkdir(DIRS.IMG, { recursive: true })
     await fs.mkdir(DIRS.PDF.UNENCRYPTED, { recursive: true })
@@ -48,7 +54,24 @@ async function init() {
     }
 }
 await init()
+
+let muhammaraModule = null
+let muhammaraAvailable = false
+
+try {
+    const imported = await import('muhammara')
+    muhammaraModule = imported.default ?? imported
+    muhammaraAvailable = true
+    // Logger.info('muhammara PDF 加密模块已加载，后续将直接使用该实现')
+} catch (err) {
+    Logger.warn(`muhammara PDF 加密模块不可用，将使用旧版 PDF 加密方法，可尝试运行 ${logger.green('pnpm approve-builds muhammara')} 修复 ，错误信息: `, err)
+}
+
 let externalJmcomicAvailable = null
+/**
+ * 检查系统是否已安装 jmcomic 命令行工具。
+ * @returns {Promise<boolean>} 如果 jmcomic 可用则返回 true，否则返回 false
+ */
 async function hasExternalJmcomic() {
     if (externalJmcomicAvailable !== null) {
         return externalJmcomicAvailable
@@ -64,7 +87,77 @@ async function hasExternalJmcomic() {
     return externalJmcomicAvailable
 }
 
+/**
+ * 使用 muhammara 对 PDF 进行加密。
+ * @param {string} sourcePath 未加密源 PDF 文件路径
+ * @param {string} targetPath 加密后输出 PDF 文件路径
+ * @param {string|number} comicId 漫画 ID，用于生成密码
+ * @returns {Promise<string|null>} 成功返回目标路径，否则返回 null
+ */
+async function encryptWithMuhammara(sourcePath, targetPath, comicId) {
+    if (!muhammaraAvailable || !muhammaraModule) {
+        return null
+    }
+
+    try {
+        Logger.debug(`使用 muhammara 加密漫画 ${logger.yellow(comicId)}`)
+        const pdfDoc = new muhammaraModule.Recipe(sourcePath, targetPath)
+        pdfDoc
+            .encrypt({
+                userPassword: comicId.toString(),
+                ownerPassword: comicId.toString(),
+                userProtectionFlag: 4,
+            })
+            .endPDF()
+
+        return targetPath
+    } catch (err) {
+        Logger.warn('muhammara 加密失败，回退到旧的 PDF 加密方法:', err)
+        return null
+    }
+}
+
+/**
+ * 使用旧版 pymupdf 命令对 PDF 进行加密。
+ * @param {string} sourcePath 未加密源 PDF 文件路径
+ * @param {string} targetPath 加密后输出 PDF 文件路径
+ * @param {string|number} comicId 漫画 ID，用于生成密码
+ * @returns {Promise<string|null>} 成功返回目标路径，否则返回 null
+ */
+async function encryptWithLegacyMethod(sourcePath, targetPath, comicId) {
+    try {
+        Logger.debug(`使用旧版 pymupdf 加密漫画 ${logger.yellow(comicId)}`)
+        const { stderr } = await promisify(execFile)('pymupdf', [
+            'clean',
+            '-compress',
+            '-encryption',
+            'aes-256',
+            '-password',
+            comicId.toString(),
+            '-user',
+            comicId.toString(),
+            '-owner',
+            comicId.toString(),
+            sourcePath,
+            targetPath,
+        ])
+
+        return stderr ? null : targetPath
+    } catch (err) {
+        Logger.warn('旧版 PDF 加密方法失败:', err)
+        return null
+    }
+}
+
+/**
+ * JM 漫画下载与 PDF 生成类。
+ */
 class Comic {
+    /**
+     * 下载指定漫画并生成未加密 PDF 文件。
+     * @param {string|number} comicId 漫画 ID
+     * @returns {Promise<string>} 生成的未加密 PDF 文件路径
+     */
     async downloadComic(comicId) {
         const comicDir = path.join(DIRS.IMG, comicId.toString())
         let dir_rule = Cfg_yaml.get('dir_rule')
@@ -84,6 +177,8 @@ class Comic {
             ? spawn('jmcomic', args)
             : jmcomic.spawn(args)
 
+        Logger.debug(`使用 ${logger.green(useSystemJmcomic ? '系统安装的jmcomic' : '内置jmcomic')} 下载漫画 ${logger.yellow(comicId)}，命令: ${logger.blue(child.spawnargs.join(' '))}`)
+
         return new Promise((resolve, reject) => {
             child.on('close', async (code) => {
                 if (code === 0) {
@@ -98,6 +193,12 @@ class Comic {
         })
     }
 
+    /**
+     * 查找指定漫画的 PDF 文件路径。
+     * @param {string|number} comicId 漫画 ID
+     * @param {boolean} [encrypted=false] 是否查找加密 PDF
+     * @returns {Promise<string|null>} 存在则返回文件路径，否则返回 null
+     */
     async findPdfFile(comicId, encrypted = false) {
         const targetDir = encrypted ? DIRS.PDF.ENCRYPTED : DIRS.PDF.UNENCRYPTED
         const filename = `${comicId}.pdf`
@@ -111,6 +212,15 @@ class Comic {
         }
     }
 
+    /**
+     * 清理 JM 缓存目录。
+     * @param {Object} options 清理选项
+     * @param {boolean} options.images 是否清理图片缓存
+     * @param {boolean} options.unencrypted 是否清理未加密 PDF
+     * @param {boolean} options.encrypted 是否清理加密 PDF
+     * @param {string|number|null} [comicId=null] 指定漫画 ID，则仅清理该漫画相关内容
+     * @returns {Promise<{deletedCount:number,sizeMB:string}>} 删除数量和总大小（MB）
+     */
     async cleanCache(
         options = {
             images: false,
@@ -153,6 +263,11 @@ class Comic {
             sizeMB: (totalSize / 1024 / 1024).toFixed(2),
         }
     }
+    /**
+     * 递归删除目标路径下的文件或目录。
+     * @param {string} targetPath 要删除的文件或目录路径
+     * @returns {Promise<{count:number,size:number}>} 删除的文件数量和总字节数
+     */
     async deletePath(targetPath) {
         let count = 0
         let totalSize = 0
@@ -178,6 +293,12 @@ class Comic {
 
         return { count, size: totalSize }
     }
+    /**
+     * 清理 PDF 目录中的文件。
+     * @param {string} pdfDir PDF 目录路径
+     * @param {string|number|null} comicId 指定漫画 ID，若为空则清理整个目录
+     * @returns {Promise<{count:number,size:number}>} 删除结果
+     */
     async cleanPdfFiles(pdfDir, comicId) {
         let count = 0
         let totalSize = 0
@@ -207,6 +328,13 @@ class Comic {
         return { count, size: totalSize }
     }
 
+    /**
+     * 加密指定漫画的 PDF 文件。
+     * - 优先使用 muhammara 加密
+     * - 如果不可用则回退到旧版 pymupdf 加密方法
+     * @param {string|number} comicId 漫画 ID
+     * @returns {Promise<string>} 加密后的 PDF 路径或源文件路径
+     */
     async encryptPDF(comicId) {
         await init()
         const sourcePath = path.join(DIRS.PDF.UNENCRYPTED, `${comicId}.pdf`)
@@ -217,16 +345,17 @@ class Comic {
                 return targetPath
             }
 
-            const pdfDoc = new muhammara.Recipe(sourcePath, targetPath)
-            pdfDoc
-                .encrypt({
-                    userPassword: comicId.toString(),
-                    ownerPassword: comicId.toString(),
-                    userProtectionFlag: 4,
-                })
-                .endPDF()
+            const muhammaraResult = await encryptWithMuhammara(sourcePath, targetPath, comicId)
+            if (muhammaraResult) {
+                return muhammaraResult
+            }
 
-            return targetPath
+            const legacyResult = await encryptWithLegacyMethod(sourcePath, targetPath, comicId)
+            if (legacyResult) {
+                return legacyResult
+            }
+
+            return sourcePath
         } catch (err) {
             Logger.error('PDF加密失败:', err)
             return sourcePath


### PR DESCRIPTION
- 默认在 pnpm i 时自动下载对应操作平台的 JM 二进制文件
- 可省去 Python 环境安装 JM 环节使用 JM
- 如果安装失败或出现错误自动回退旧版Python逻辑

> [!WARNING]
> 使用 Github Copilot 生成，不保证代码质量及功能完整性